### PR TITLE
Hashing password according to wallet.dat format

### DIFF
--- a/moat-cli/src/command.rs
+++ b/moat-cli/src/command.rs
@@ -200,7 +200,7 @@ impl Command {
         blockchain_access_config: &BlockchainAccessConfig,
     ) -> Result<RunResult, Error> {
         let wallet_accessor =
-            WalletAccessor::new(wallet_path.clone(), psw.clone());
+            WalletAccessor::create(wallet_path.clone(), psw.clone())?;
         let note_hashes: Vec<BlsScalar> = wallet_accessor
             .get_notes(blockchain_access_config)
             .await?

--- a/moat-cli/src/main.rs
+++ b/moat-cli/src/main.rs
@@ -67,7 +67,10 @@ async fn main() -> Result<(), CliError> {
     interactor.run_loop().await?;
 
     #[rustfmt::skip]
+    // old wallet.dat file format:
     // cargo r --release --bin moat-cli -- --wallet-path ~/.dusk/rusk-wallet --config-path ./moat-cli/config.toml --lp-config-path ./moat-cli/lp.json --pwd-hash 7f2611ba158b6dcea4a69c229c303358c5e04493abeadee106a4bfa464d55787 ./moat-cli/request.json
+    // new wallet.dat file format:
+    // cargo r --release --bin moat-cli -- --wallet-path ~/.dusk/rusk-wallet --config-path ./moat-cli/config.toml --lp-config-path ./moat-cli/lp.json --pwd-hash 5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8 ./moat-cli/request.json
 
     Ok(())
 }

--- a/moat-core/src/blockchain_payloads/payload_sender.rs
+++ b/moat-core/src/blockchain_payloads/payload_sender.rs
@@ -32,7 +32,7 @@ impl PayloadSender {
         M: AsRef<str>,
     {
         let wallet_accessor =
-            WalletAccessor::new(wallet_path.clone(), password.clone());
+            WalletAccessor::create(wallet_path.clone(), password.clone())?;
         let tx_id = wallet_accessor
             .execute_contract_method(
                 payload,

--- a/wallet-accessor/Cargo.toml
+++ b/wallet-accessor/Cargo.toml
@@ -15,3 +15,4 @@ serde = { version = "1", features = ["derive"] }
 toml-base-config = "0.1"
 sha2 = "0.10"
 hex = "0.4"
+blake3 = "1.4"


### PR DESCRIPTION
The way password is hashed depends on the format of wallet.dat.
This PR implements the functionality needed to support password hashing in both formet.
Implements issue #28 